### PR TITLE
fix: escape php_binary path to ensure correct usage as shell argument

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -72,7 +72,7 @@ class Installer
         $onlyEnabled    = $enabled ? ' --only-enabled' : '';
 
         // sub process settings
-        $cmd   = PHP_BINARY . ' '  . $executable . ' install'
+        $cmd   = escapeshellarg(PHP_BINARY) . ' '  . $executable . ' install'
                  . $ansi . ' --no-interaction' . $forceOrSkip . $onlyEnabled
                  . $configuration . $repository;
         $pipes = [];


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/captainhookphp/hook-installer/issues/3), by formatting the `PHP_BINARY` path to a string, that can safely be consumed as a shell argument.